### PR TITLE
Fix/button children

### DIFF
--- a/src/components/__tests__/button.test.tsx
+++ b/src/components/__tests__/button.test.tsx
@@ -119,4 +119,12 @@ describe('Forms > Button', () => {
 		expect(getByTestId(testID)).toBeTruthy();
 		expect(getByText('Test')).toBeTruthy();
 	});
+
+	it('should add children', async () => {
+		const { getByTestId, getByText } = renderWithProviders(
+			<Button testID={testID}>Test</Button>
+		);
+		expect(getByTestId(testID)).toBeTruthy();
+		expect(getByText('Test')).toBeTruthy();
+	});
 });

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -11,6 +11,7 @@ export const Button: React.FC<ButtonProps> = ({
 	inverted,
 	onPressIn,
 	onPressOut,
+	children,
 	...props
 }) => {
 	const [iconColor, pressableProps] = useIconColor(buttonTheme.variants, {
@@ -20,9 +21,9 @@ export const Button: React.FC<ButtonProps> = ({
 	});
 
 	const _isLoadingText = useMemo(() => {
-		if (props.isLoading) return props.children as string;
+		if (props.isLoading) return children as string;
 		return undefined;
-	}, [props.isLoading, props.children]);
+	}, [props.isLoading, children]);
 
 	return (
 		<NBButton
@@ -46,7 +47,7 @@ export const Button: React.FC<ButtonProps> = ({
 			isLoadingText={_isLoadingText}
 			spinnerPlacement="end"
 		>
-			{props.variant}
+			{children}
 		</NBButton>
 	);
 };


### PR DESCRIPTION
Fixes error where `variant` was mistakenly been used as `children`